### PR TITLE
feat: SAAA-10678 ensure we are able to get text track on slot change

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -109,6 +109,12 @@ export default class Video extends Component {
     }
   };
 
+  _onTextTracks = (event) => {
+    if (this.props.onTextTracks) {
+      this.props.onTextTracks(event.nativeEvent);
+    }
+  };
+
   _onError = (event) => {
     if (this.props.onError) {
       this.props.onError(event.nativeEvent);
@@ -307,6 +313,7 @@ export default class Video extends Component {
       },
       onVideoLoadStart: this._onLoadStart,
       onVideoLoad: this._onLoad,
+      onTextTracks: this._onTextTracks,
       onVideoError: this._onError,
       onVideoProgress: this._onProgress,
       onVideoSeek: this._onSeek,
@@ -494,6 +501,7 @@ Video.propTypes = {
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,
   onLoad: PropTypes.func,
+  onTextTracks: PropTypes.func,
   onBuffer: PropTypes.func,
   onError: PropTypes.func,
   onProgress: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1127,7 +1127,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        // Do Nothing.
+        eventEmitter.textTracks(getTextTrackInfo());
     }
 
     @Override

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -47,6 +47,7 @@ class VideoEventEmitter {
     private static final String EVENT_AUDIO_BECOMING_NOISY = "onVideoAudioBecomingNoisy";
     private static final String EVENT_AUDIO_FOCUS_CHANGE = "onAudioFocusChanged";
     private static final String EVENT_PLAYBACK_RATE_CHANGE = "onPlaybackRateChange";
+    private static final String EVENT_TEXT_TRACKS = "onTextTracks";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -68,6 +69,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_BECOMING_NOISY,
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
+            EVENT_TEXT_TRACKS,
             EVENT_BANDWIDTH,
     };
 
@@ -92,6 +94,7 @@ class VideoEventEmitter {
             EVENT_AUDIO_BECOMING_NOISY,
             EVENT_AUDIO_FOCUS_CHANGE,
             EVENT_PLAYBACK_RATE_CHANGE,
+            EVENT_TEXT_TRACKS,
             EVENT_BANDWIDTH,
     })
     @interface VideoEvents {
@@ -169,6 +172,13 @@ class VideoEventEmitter {
         event.putBoolean(EVENT_PROP_STEP_FORWARD, true);
 
         receiveEvent(EVENT_LOAD, event);
+    }
+
+    void textTracks(ArrayList<Track> textTracks){
+        WritableMap event = Arguments.createMap();
+        event.putArray(EVENT_PROP_TEXT_TRACKS, textTracks);
+
+        receiveEvent(EVENT_TEXT_TRACKS, arrayToObject(EVENT_PROP_TEXT_TRACKS, event));
     }
 
     void progressChanged(double currentPosition, double bufferedDuration, double seekableDuration, double currentPlaybackTime) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -174,11 +174,8 @@ class VideoEventEmitter {
         receiveEvent(EVENT_LOAD, event);
     }
 
-    void textTracks(ArrayList<Track> textTracks){
-        WritableMap event = Arguments.createMap();
-        event.putArray(EVENT_PROP_TEXT_TRACKS, textTracks);
-
-        receiveEvent(EVENT_TEXT_TRACKS, arrayToObject(EVENT_PROP_TEXT_TRACKS, event));
+    void textTracks(WritableArray textTracks){
+        receiveEvent(EVENT_TEXT_TRACKS, textTracks);
     }
 
     void progressChanged(double currentPosition, double bufferedDuration, double seekableDuration, double currentPlaybackTime) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -175,7 +175,10 @@ class VideoEventEmitter {
     }
 
     void textTracks(WritableArray textTracks){
-        receiveEvent(EVENT_TEXT_TRACKS, textTracks);
+        WritableMap event = Arguments.createMap();
+        event.putArray(EVENT_PROP_TEXT_TRACKS, textTracks);
+
+        receiveEvent(EVENT_TEXT_TRACKS, event);
     }
 
     void progressChanged(double currentPosition, double bufferedDuration, double seekableDuration, double currentPlaybackTime) {


### PR DESCRIPTION
1) Making use of exoplayer listener event to detect text track changes.
2) New prop onTextTracks was introduced which will be responsible to give us updated text tracks 