### PR TITLE
Fix progress update interval

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1309,6 +1309,9 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setProgressUpdateInterval(final float progressUpdateInterval) {
         mProgressUpdateInterval = progressUpdateInterval;
+        progressHandler.removeCallbacksAndMessages(null);
+        Message msg = Message.obtain(progressHandler, SHOW_PROGRESS);
+        progressHandler.sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
     }
 
     public void setReportBandwidth(boolean reportBandwidth) {


### PR DESCRIPTION
I observed that there is a delay of 10 seconds in updating the current time in the progress bar when `progressUpdateInterval` is changed from 10 seconds to 1 second. 

So I created this PR to fix it.