### PR TITLE
fix: last position and clean up

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -298,16 +298,12 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onHostDestroy() {
-        if (mainHandler != null) {
-            mainHandler.removeCallbacksAndMessages(null);
-        }
+        mainHandler.removeCallbacksAndMessages(null);
         stopPlayback();
     }
 
     public void cleanUpResources() {
-        if (mainHandler != null) {
-            mainHandler.removeCallbacksAndMessages(null);
-        }
+        mainHandler.removeCallbacksAndMessages(null);
         stopPlayback();
     }
 
@@ -1309,11 +1305,9 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setProgressUpdateInterval(final float progressUpdateInterval) {
         mProgressUpdateInterval = progressUpdateInterval;
-        if (progressHandler != null) {
-            progressHandler.removeCallbacksAndMessages(null);
-            Message msg = Message.obtain(progressHandler, SHOW_PROGRESS);
-            progressHandler.sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
-        }
+        progressHandler.removeCallbacksAndMessages(null);
+        Message msg = Message.obtain(progressHandler, SHOW_PROGRESS);
+        progressHandler.sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));
     }
 
     public void setReportBandwidth(boolean reportBandwidth) {
@@ -1743,15 +1737,14 @@ class ReactExoplayerView extends FrameLayout implements
         exoPlayerView.setSubtitleStyle(style);
     }
 
-    public void fastForwardOrRewind(long incrementMs) {
-        if (mainHandler != null) {
-            mainHandler.removeCallbacksAndMessages(null);
-        }
+    public void fastForwardOrRewind(long incrementMs, long lastPosition) {
+        mainHandler.removeCallbacksAndMessages(null);
         if (player == null || incrementMs == 1000L) {
             return;
         }
-        long currentPosition = seekTime;
-        if(seekTime <= 0) {
+
+        long currentPosition = lastPosition;
+        if (currentPosition < 0) {
             currentPosition = player.getCurrentPosition();
         }
         long newPosition = currentPosition + incrementMs;
@@ -1760,10 +1753,9 @@ class ReactExoplayerView extends FrameLayout implements
         long mediaDuration = player.getDuration();
         newPosition = Math.max(0, Math.min(newPosition, mediaDuration));
         seekTo(newPosition);
-        currentPosition = newPosition;
-
+        final long lastSeekPosition = newPosition;
         if (newPosition > 0 && newPosition < mediaDuration) {
-            mainHandler.postDelayed(() -> fastForwardOrRewind(incrementMs), 1000);
+            mainHandler.postDelayed(() -> fastForwardOrRewind(incrementMs, lastSeekPosition), 1000);
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -374,7 +374,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_FF_RW)
     public void fastForwardOrRewind(final ReactExoplayerView videoView, final String incrementMs) {
-        videoView.fastForwardOrRewind(Long.parseLong(incrementMs));
+        videoView.fastForwardOrRewind(Long.parseLong(incrementMs), -1L);
     }
 
     private boolean startsWithValidScheme(String uriString) {


### PR DESCRIPTION
1. I noticed that it seeks 2 seconds more than expected when fast forwarding and rewinding. i.e. FF by 4x, it seeks 6 seconds every time.
2. The condition check for `mainHandler` and `progressHandler` is unnecessary because they will not be empty where they are used. Therefore, I have removed both of them.