### PR TITLE
Use Default  Load Control 

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2030,7 +2030,17 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setBackBufferDurationMs(int backBufferDurationMs) {
-
+        Runtime runtime = Runtime.getRuntime();
+        long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+        long freeMemory = runtime.maxMemory() - usedMemory;
+        long reserveMemory = (long)minBackBufferMemoryReservePercent * runtime.maxMemory();
+        if (reserveMemory > freeMemory) {
+            // We don't have enough memory in reserve so we will
+            Log.w("ExoPlayer Warning", "Not enough reserve memory, setting back buffer to 0ms to reduce memory pressure!");
+            this.backBufferDurationMs = 0;
+            return;
+        }
+        this.backBufferDurationMs = backBufferDurationMs;
     }
 
     public void setContentStartTime(int contentStartTime) {


### PR DESCRIPTION
`if(runtime.freeMemory() == 0)` is always true, and it triggers `runtime. gc()`, which is causing the jittering effect.
Reverting it to the default load control in v5.