### PR TITLE
fix: SAAA-12238 ensure youbora is initialised after player.prepare

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -835,7 +835,9 @@ class ReactExoplayerView extends FrameLayout implements
         startBufferCheckTimer();
 
         Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
-        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
+        if (analyticsMeta != null){
+        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsData.toString());
+        }
         Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
         // Log.d("Youboraaaaa","finishPlayerInitialization5: " + (analyticsMeta != null && analyticsMeta.getString("contentId")));
@@ -2166,7 +2168,9 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
+        if (analyticsMeta != null){
         Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
+        }
         // if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
         //     initialiseYoubora();
         // }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -836,7 +836,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.d("Youboraaaaa","finishPlayerInitialization");
 
-        if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
+        if (player != null && this.analyticsMeta != null && youboraPlugin == null && contentId != this.analyticsMeta.getString("contentId")) {
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -838,9 +838,9 @@ class ReactExoplayerView extends FrameLayout implements
         Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta);
         Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
-        Log.d("Youboraaaaa","finishPlayerInitialization5: " + analyticsMeta.getString("contentId"));
+        // Log.d("Youboraaaaa","finishPlayerInitialization5: " + (analyticsMeta != null && analyticsMeta.getString("contentId")));
 
-        if (player != null && analyticsMeta != null && youboraPlugin == null && contentId != analyticsMeta.getString("contentId")) {
+        if (player != null && youboraPlugin == null  && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -825,6 +825,8 @@ class ReactExoplayerView extends FrameLayout implements
         startBufferCheckTimer();
 
         Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+player);
+        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+analyticsMeta);
+        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+this.analyticsMeta);
 
         if (analyticsMeta != null) {
         Log.d("Youboraaaaaa", "finishPlayerInitialization contentIsLive: "+analyticsMeta.getBoolean("contentIsLive"));
@@ -1016,6 +1018,7 @@ class ReactExoplayerView extends FrameLayout implements
             player.removeListener(this);
             trackSelector = null;
             player = null;
+            Log.d("Youboraaaa","releasePlayer youboraPlugin: "+youboraPlugin);
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
@@ -1644,12 +1647,12 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
+                Log.d("Youboraaaa","isSourceEqual not equal youboraPlugin: "+youboraPlugin);
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
                     this.youboraPlugin = null;
                     this.contentId = null;
-                    this.analyticsMeta = null;
                 }
                 reloadSource();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,12 +824,6 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa: ","finishPlayerInitialization player: "+player);
-        Log.d("Youboraaaaa: ","finishPlayerInitialization youboraPlugin: "+youboraPlugin);
-        if (analyticsMeta != null) {
-            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+analyticsMeta.toString());
-            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+contentId);
-        }
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }
@@ -1011,7 +1005,6 @@ class ReactExoplayerView extends FrameLayout implements
                 youboraPlugin = null;
                 contentId = null;
                 analyticsMeta = null;
-                Log.d("Youboraaaaaa","releasePlayer");
             }
         }
         if (adsLoader != null) {
@@ -1640,7 +1633,6 @@ class ReactExoplayerView extends FrameLayout implements
                     youboraPlugin = null;
                     contentId = null;
                     analyticsMeta = null;
-                    Log.d("Youboraaaaaa","isSourceEqual");
                 }
                 reloadSource();
             }
@@ -2163,12 +2155,6 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
-        Log.d("Youboraaaaa: ","player: "+player);
-        Log.d("Youboraaaaa: ","youboraPlugin: "+youboraPlugin);
-        if (analyticsData != null) {
-            Log.d("Youboraaaaa: ","setAnalyticsMeta: "+analyticsData.toString());
-            Log.d("Youboraaaaa: ","setAnalyticsMeta: "+contentId);
-        }
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2155,7 +2155,9 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
+        if (analyticsData != null) {
         Log.d("Youboraaaaa: ","setAnalyticsMeta: "+analyticsData.toString());
+        }
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -624,6 +624,9 @@ class ReactExoplayerView extends FrameLayout implements
         if (activity == null) return;
 
         youboraPlugin.setActivity(activity);
+        Log.d("Youboraaaaaa","initialiseYoubora player: "+player);
+        Log.d("Youboraaaaaa","initialiseYoubora youboraPlugin: "+youboraPlugin);
+        Log.d("Youboraaaaaa","initialiseYoubora youboraPlugin.getAdapter(): "+youboraPlugin.getAdapter());
         if (player != null && youboraPlugin != null && youboraPlugin.getAdapter() == null) {
             Exoplayer2Adapter adapter = new Exoplayer2Adapter(player);
             youboraPlugin.setAdapter(adapter);
@@ -747,9 +750,6 @@ class ReactExoplayerView extends FrameLayout implements
 
         PlaybackParameters params = new PlaybackParameters(rate, 1f);
         player.setPlaybackParameters(params);
-        // if (analyticsMeta != null) {
-        //     initialiseYoubora();
-        // }
         changeAudioOutput(this.audioOutput);
     }
 
@@ -835,15 +835,17 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
+        Log.d("Youboraaaaa","finishPlayerInitialization player: " + player);
         if (analyticsMeta != null){
-            Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
+            Log.d("Youboraaaaa","finishPlayerInitialization analyticsMeta: " + analyticsMeta.toString());
+            Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId != analyticsMeta.getString("contentId"));
         }
-        Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
-        Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
+        Log.d("Youboraaaaa","finishPlayerInitialization youboraPlugin: " + youboraPlugin);
+        Log.d("Youboraaaaa","finishPlayerInitialization contentId: " + contentId);
         this.playerInitialised = true;
 
-        if (player != null && youboraPlugin == null  && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+        if (player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+            Log.d("Youboraaaaa","Initialised youbora inside finishPlayerInitialization");
             initialiseYoubora();
         }
     }
@@ -2170,12 +2172,16 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
         if (analyticsData != null){
-            Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
+            Log.d("Youboraaaaa","setAnalyticsMeta analyticsData: " + analyticsData.toString());
+            Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId != analyticsMeta.getString("contentId"));
         }
 
-        Log.d("Youboraaaaa","playerInitialised: " + playerInitialised);
+        Log.d("Youboraaaaa","setAnalyticsMeta player: " + player);
+        Log.d("Youboraaaaa","setAnalyticsMeta playerInitialised: " + playerInitialised);
+        Log.d("Youboraaaaa","setAnalyticsMeta youboraPlugin: " + youboraPlugin);
 
         if (playerInitialised && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+            Log.d("Youboraaaaa","Initialised youbora inside setAnalyticsMeta");
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -631,6 +631,8 @@ class ReactExoplayerView extends FrameLayout implements
             Exoplayer2Adapter adapter = new Exoplayer2Adapter(player);
             youboraPlugin.setAdapter(adapter);
             youboraPlugin.getAdapter().fireStart();
+            // Reset playerInitialised so that youbora detects it next time when we change channel
+            this.playerInitialised = false;
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -836,7 +836,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.d("Youboraaaaa","finishPlayerInitialization");
 
-        if (player != null && this.analyticsData != null && youboraPlugin == null && contentId != this.analyticsData.getString("contentId")) {
+        if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -530,9 +530,7 @@ class ReactExoplayerView extends FrameLayout implements
     private void initialiseYoubora() {
         if (analyticsMeta == null) return;
 
-        if (BuildConfig.DEBUG) {
-            YouboraLog.setDebugLevel(YouboraLog.Level.VERBOSE);
-        }
+        YouboraLog.setDebugLevel(YouboraLog.Level.VERBOSE);
 
         contentId = analyticsMeta.getString("contentId");
 
@@ -748,9 +746,9 @@ class ReactExoplayerView extends FrameLayout implements
 
         PlaybackParameters params = new PlaybackParameters(rate, 1f);
         player.setPlaybackParameters(params);
-        if (analyticsMeta != null) {
-            initialiseYoubora();
-        }
+        // if (analyticsMeta != null) {
+        //     initialiseYoubora();
+        // }
         changeAudioOutput(this.audioOutput);
     }
 
@@ -835,6 +833,12 @@ class ReactExoplayerView extends FrameLayout implements
         setControls(controls);
         applyModifiers();
         startBufferCheckTimer();
+
+        Log.d("Youboraaaaa","finishPlayerInitialization");
+
+        if (player != null && this.analyticsData != null && youboraPlugin == null && contentId != this.analyticsData.getString("contentId")) {
+            initialiseYoubora();
+        }
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {
@@ -2158,15 +2162,15 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
-        if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
-            initialiseYoubora();
-        }
-        if (player != null && analyticsData != null && youboraPlugin != null && youboraPlugin.getAdapter() != null && contentId != analyticsData.getString("contentId")) {
-            youboraPlugin.getAdapter().unregisterListeners();
-            youboraPlugin.getAdapter().fireStop();
-            youboraPlugin = null;
-            initialiseYoubora();
-        }
+        // if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
+        //     initialiseYoubora();
+        // }
+        // if (player != null && analyticsData != null && youboraPlugin != null && youboraPlugin.getAdapter() != null && contentId != analyticsData.getString("contentId")) {
+        //     youboraPlugin.getAdapter().unregisterListeners();
+        //     youboraPlugin.getAdapter().fireStop();
+        //     youboraPlugin = null;
+        //     initialiseYoubora();
+        // }
     }
 
     public void setAssetId(String assetId) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1651,6 +1651,7 @@ class ReactExoplayerView extends FrameLayout implements
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
                     youboraPlugin = null;
+                    contentId = null;
                 }
                 reloadSource();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -533,6 +533,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (BuildConfig.DEBUG) {
             YouboraLog.setDebugLevel(YouboraLog.Level.VERBOSE);
         }
+
         contentId = analyticsMeta.getString("contentId");
 
         Options youboraOptions = new Options();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1001,7 +1001,11 @@ class ReactExoplayerView extends FrameLayout implements
             trackSelector = null;
             player = null;
             if (youboraPlugin != null) {
+                youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
+                youboraPlugin = null;
+                contentId = null;
+                analyticsMeta = null;
             }
         }
         if (adsLoader != null) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -835,7 +835,7 @@ class ReactExoplayerView extends FrameLayout implements
         startBufferCheckTimer();
 
         Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
-        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta);
+        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
         Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
         // Log.d("Youboraaaaa","finishPlayerInitialization5: " + (analyticsMeta != null && analyticsMeta.getString("contentId")));

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -838,7 +838,7 @@ class ReactExoplayerView extends FrameLayout implements
         Log.d("Youboraaaaa","finishPlayerInitialization player: " + player);
         if (analyticsMeta != null){
             Log.d("Youboraaaaa","finishPlayerInitialization analyticsMeta: " + analyticsMeta.toString());
-            Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId != analyticsMeta.getString("contentId"));
+            Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
         }
         Log.d("Youboraaaaa","finishPlayerInitialization youboraPlugin: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization contentId: " + contentId);
@@ -2173,7 +2173,7 @@ class ReactExoplayerView extends FrameLayout implements
         this.analyticsMeta = analyticsData;
         if (analyticsData != null){
             Log.d("Youboraaaaa","setAnalyticsMeta analyticsData: " + analyticsData.toString());
-            Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId != analyticsMeta.getString("contentId"));
+            Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
         }
 
         Log.d("Youboraaaaa","setAnalyticsMeta player: " + player);

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -828,8 +828,9 @@ class ReactExoplayerView extends FrameLayout implements
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                youboraPlugin = null;
+                this.youboraPlugin = null;
             }
+            Log.d("Youboraaaaaa", "finishPlayerInitialization youboraPlugin: "+youboraPlugin);
             if (youboraPlugin == null) {
                 initialiseYoubora();
             }
@@ -1009,9 +1010,9 @@ class ReactExoplayerView extends FrameLayout implements
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                youboraPlugin = null;
-                contentId = null;
-                analyticsMeta = null;
+                this.youboraPlugin = null;
+                this.contentId = null;
+                this.analyticsMeta = null;
             }
         }
         if (adsLoader != null) {
@@ -1637,9 +1638,9 @@ class ReactExoplayerView extends FrameLayout implements
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
-                    youboraPlugin = null;
-                    contentId = null;
-                    analyticsMeta = null;
+                    this.youboraPlugin = null;
+                    this.contentId = null;
+                    this.analyticsMeta = null;
                 }
                 reloadSource();
             }
@@ -2164,11 +2165,12 @@ class ReactExoplayerView extends FrameLayout implements
         this.analyticsMeta = analyticsData;
 
         if (player != null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-            if (youboraPlugin != null ) {
+            if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                youboraPlugin = null;
+                this.youboraPlugin = null;
             }
+            Log.d("Youboraaaaaa", "youboraPlugin: "+youboraPlugin);
             if (youboraPlugin == null) {
                 initialiseYoubora();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -822,6 +822,7 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
+        Log.d("Youboraaaaa: ", "check if finishPlayerInitialization was called")
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }
@@ -2154,6 +2155,7 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
+        Log.d("Youboraaaaa: ","setAnalyticsMeta: "+analyticsData.toString());
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -250,7 +250,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
-    // private boolean playerInitialised = false;
+    private boolean triedYouboraInit = false;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -628,6 +628,7 @@ class ReactExoplayerView extends FrameLayout implements
             Exoplayer2Adapter adapter = new Exoplayer2Adapter(player);
             youboraPlugin.setAdapter(adapter);
             youboraPlugin.getAdapter().fireStart();
+            this.triedYouboraInit=false;
             // Reset playerInitialised so that youbora detects it next time when we change channel
             // this.playerInitialised = false;
         }
@@ -834,8 +835,8 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-
-        if (player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+        if (!triedYouboraInit && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+            this.triedYouboraInit=true;
             initialiseYoubora();
         }
     }
@@ -2162,6 +2163,11 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
+
+        if (!triedYouboraInit && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+            this.triedYouboraInit=true;
+            initialiseYoubora();
+        }
     }
 
     public void setAssetId(String assetId) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1641,7 +1641,7 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
-                analyticsMeta = null;
+                Log.d("Youboraaaaaaa","isSourceEqual: "+isSourceEqual);
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2166,6 +2166,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
+        Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
         // if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
         //     initialiseYoubora();
         // }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,24 +824,13 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+player);
-        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+analyticsMeta);
-        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+this.analyticsMeta);
-
-        if (analyticsMeta != null) {
-        Log.d("Youboraaaaaa", "finishPlayerInitialization contentIsLive: "+analyticsMeta.getBoolean("contentIsLive"));
-        Log.d("Youboraaaaaa", "finishPlayerInitialization contentId: "+contentId);
-        Log.d("Youboraaaaaa", "finishPlayerInitialization contentId: "+analyticsMeta.getString("contentId"));
-
-        }
-
         if (player != null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
                 this.youboraPlugin = null;
             }
-            Log.d("Youboraaaaaa", "finishPlayerInitialization youboraPlugin: "+youboraPlugin);
+            
             if (youboraPlugin == null) {
                 initialiseYoubora();
             }
@@ -1018,13 +1007,11 @@ class ReactExoplayerView extends FrameLayout implements
             player.removeListener(this);
             trackSelector = null;
             player = null;
-            Log.d("Youboraaaa","releasePlayer youboraPlugin: "+youboraPlugin);
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
                 this.youboraPlugin = null;
                 this.contentId = null;
-                this.analyticsMeta = null;
             }
         }
         if (adsLoader != null) {
@@ -1647,7 +1634,6 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
-                Log.d("Youboraaaa","isSourceEqual not equal youboraPlugin: "+youboraPlugin);
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
@@ -2176,21 +2162,12 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
- Log.d("Youboraaaaaa", "setAnalyticsMeta player"+player);
-        if (analyticsMeta != null) {
-        Log.d("Youboraaaaaa", "setAnalyticsMeta contentIsLive: "+analyticsMeta.getBoolean("contentIsLive"));
-        Log.d("Youboraaaaaa", "setAnalyticsMeta contentId: "+contentId);
-        Log.d("Youboraaaaaa", "setAnalyticsMeta contentId: "+analyticsMeta.getString("contentId"));
-
-        }
-
         if (player != null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
                 this.youboraPlugin = null;
             }
-            Log.d("Youboraaaaaa", "setAnalyticsMeta youboraPlugin: "+youboraPlugin);
             if (youboraPlugin == null) {
                 initialiseYoubora();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,8 +824,15 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-            initialiseYoubora();
+        if (player != null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
+            if (youboraPlugin != null) {
+                youboraPlugin.getAdapter().unregisterListeners();
+                youboraPlugin.getAdapter().fireStop();
+                youboraPlugin = null;
+            }
+            if (youboraPlugin == null) {
+                initialiseYoubora();
+            }
         }
     }
 
@@ -2156,8 +2163,15 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
-        if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-            initialiseYoubora();
+        if (player != null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
+            if (youboraPlugin != null ) {
+                youboraPlugin.getAdapter().unregisterListeners();
+                youboraPlugin.getAdapter().fireStop();
+                youboraPlugin = null;
+            }
+            if (youboraPlugin == null) {
+                initialiseYoubora();
+            }
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -250,6 +250,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
+    private boolean playerInitialised = false;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -836,11 +837,11 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
         if (analyticsMeta != null){
-        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
+            Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
         }
         Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
-        // Log.d("Youboraaaaa","finishPlayerInitialization5: " + (analyticsMeta != null && analyticsMeta.getString("contentId")));
+        this.playerInitialised = true;
 
         if (player != null && youboraPlugin == null  && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
@@ -2169,17 +2170,14 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
         if (analyticsData != null){
-        Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
+            Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
         }
-        // if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {
-        //     initialiseYoubora();
-        // }
-        // if (player != null && analyticsData != null && youboraPlugin != null && youboraPlugin.getAdapter() != null && contentId != analyticsData.getString("contentId")) {
-        //     youboraPlugin.getAdapter().unregisterListeners();
-        //     youboraPlugin.getAdapter().fireStop();
-        //     youboraPlugin = null;
-        //     initialiseYoubora();
-        // }
+
+        Log.d("Youboraaaaa","playerInitialised: " + playerInitialised);
+
+        if (playerInitialised && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+            initialiseYoubora();
+        }
     }
 
     public void setAssetId(String assetId) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -530,8 +530,9 @@ class ReactExoplayerView extends FrameLayout implements
     private void initialiseYoubora() {
         if (analyticsMeta == null) return;
 
-        YouboraLog.setDebugLevel(YouboraLog.Level.VERBOSE);
-
+        if (BuildConfig.DEBUG) {
+            YouboraLog.setDebugLevel(YouboraLog.Level.VERBOSE);
+        }
         contentId = analyticsMeta.getString("contentId");
 
         Options youboraOptions = new Options();
@@ -822,7 +823,6 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa: ", "check if finishPlayerInitialization was called");
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }
@@ -2155,9 +2155,6 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
-        if (analyticsData != null) {
-        Log.d("Youboraaaaa: ","setAnalyticsMeta: "+analyticsData.toString());
-        }
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -250,7 +250,7 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
-    private boolean playerInitialised = false;
+    // private boolean playerInitialised = false;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -632,7 +632,7 @@ class ReactExoplayerView extends FrameLayout implements
             youboraPlugin.setAdapter(adapter);
             youboraPlugin.getAdapter().fireStart();
             // Reset playerInitialised so that youbora detects it next time when we change channel
-            this.playerInitialised = false;
+            // this.playerInitialised = false;
         }
     }
 
@@ -837,14 +837,14 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa","finishPlayerInitialization player: " + player);
-        if (analyticsMeta != null){
-            Log.d("Youboraaaaa","finishPlayerInitialization analyticsMeta: " + analyticsMeta.toString());
-            Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
-        }
-        Log.d("Youboraaaaa","finishPlayerInitialization youboraPlugin: " + youboraPlugin);
-        Log.d("Youboraaaaa","finishPlayerInitialization contentId: " + contentId);
-        this.playerInitialised = true;
+        // Log.d("Youboraaaaa","finishPlayerInitialization player: " + player);
+        // if (analyticsMeta != null){
+        //     Log.d("Youboraaaaa","finishPlayerInitialization analyticsMeta: " + analyticsMeta.toString());
+        //     Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
+        // }
+        // Log.d("Youboraaaaa","finishPlayerInitialization youboraPlugin: " + youboraPlugin);
+        // Log.d("Youboraaaaa","finishPlayerInitialization contentId: " + contentId);
+        // this.playerInitialised = true;
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
             Log.d("Youboraaaaa","Initialised youbora inside finishPlayerInitialization");
@@ -1652,6 +1652,7 @@ class ReactExoplayerView extends FrameLayout implements
                     youboraPlugin.getAdapter().fireStop();
                     youboraPlugin = null;
                     contentId = null;
+                    analyticsMeta = null;
                 }
                 reloadSource();
             }
@@ -2174,19 +2175,19 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
-        if (analyticsData != null){
-            Log.d("Youboraaaaa","setAnalyticsMeta analyticsData: " + analyticsData.toString());
-            Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
-        }
+        // if (analyticsData != null){
+        //     Log.d("Youboraaaaa","setAnalyticsMeta analyticsData: " + analyticsData.toString());
+        //     Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
+        // }
 
-        Log.d("Youboraaaaa","setAnalyticsMeta player: " + player);
-        Log.d("Youboraaaaa","setAnalyticsMeta playerInitialised: " + playerInitialised);
-        Log.d("Youboraaaaa","setAnalyticsMeta youboraPlugin: " + youboraPlugin);
+        // Log.d("Youboraaaaa","setAnalyticsMeta player: " + player);
+        // Log.d("Youboraaaaa","setAnalyticsMeta playerInitialised: " + playerInitialised);
+        // Log.d("Youboraaaaa","setAnalyticsMeta youboraPlugin: " + youboraPlugin);
 
-        if (playerInitialised && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
-            Log.d("Youboraaaaa","Initialised youbora inside setAnalyticsMeta");
-            initialiseYoubora();
-        }
+        // if (playerInitialised && player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
+        //     Log.d("Youboraaaaa","Initialised youbora inside setAnalyticsMeta");
+        //     initialiseYoubora();
+        // }
     }
 
     public void setAssetId(String assetId) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,6 +824,15 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
+        Log.d("Youboraaaaaa", "finishPlayerInitialization player: "+player);
+
+        if (analyticsMeta != null) {
+        Log.d("Youboraaaaaa", "finishPlayerInitialization contentIsLive: "+analyticsMeta.getBoolean("contentIsLive"));
+        Log.d("Youboraaaaaa", "finishPlayerInitialization contentId: "+contentId);
+        Log.d("Youboraaaaaa", "finishPlayerInitialization contentId: "+analyticsMeta.getString("contentId"));
+
+        }
+
         if (player != null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
@@ -2164,13 +2173,21 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
+ Log.d("Youboraaaaaa", "setAnalyticsMeta player"+player);
+        if (analyticsMeta != null) {
+        Log.d("Youboraaaaaa", "setAnalyticsMeta contentIsLive: "+analyticsMeta.getBoolean("contentIsLive"));
+        Log.d("Youboraaaaaa", "setAnalyticsMeta contentId: "+contentId);
+        Log.d("Youboraaaaaa", "setAnalyticsMeta contentId: "+analyticsMeta.getString("contentId"));
+
+        }
+
         if (player != null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
                 this.youboraPlugin = null;
             }
-            Log.d("Youboraaaaaa", "youboraPlugin: "+youboraPlugin);
+            Log.d("Youboraaaaaa", "setAnalyticsMeta youboraPlugin: "+youboraPlugin);
             if (youboraPlugin == null) {
                 initialiseYoubora();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -822,7 +822,7 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa: ", "check if finishPlayerInitialization was called")
+        Log.d("Youboraaaaa: ", "check if finishPlayerInitialization was called");
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -836,7 +836,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
         if (analyticsMeta != null){
-        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsData.toString());
+        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta.toString());
         }
         Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
         Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
@@ -2168,7 +2168,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
-        if (analyticsMeta != null){
+        if (analyticsData != null){
         Log.d("Youboraaaaa","setAnalyticsMeta: " + analyticsData.toString());
         }
         // if (player != null && analyticsData != null && youboraPlugin == null && contentId != analyticsData.getString("contentId")) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -834,7 +834,11 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa","finishPlayerInitialization");
+        Log.d("Youboraaaaa","finishPlayerInitialization: "+player);
+        Log.d("Youboraaaaa","finishPlayerInitialization"+this.analyticsMeta);
+        Log.d("Youboraaaaa","finishPlayerInitialization"+youboraPlugin);
+        Log.d("Youboraaaaa","finishPlayerInitialization"+contentId);
+        Log.d("Youboraaaaa","finishPlayerInitialization"+this.analyticsMeta.getString("contentId"));
 
         if (player != null && this.analyticsMeta != null && youboraPlugin == null && contentId != this.analyticsMeta.getString("contentId")) {
             initialiseYoubora();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1011,6 +1011,7 @@ class ReactExoplayerView extends FrameLayout implements
                 youboraPlugin = null;
                 contentId = null;
                 analyticsMeta = null;
+                Log.d("Youboraaaaaa","releasePlayer");
             }
         }
         if (adsLoader != null) {
@@ -1639,6 +1640,7 @@ class ReactExoplayerView extends FrameLayout implements
                     youboraPlugin = null;
                     contentId = null;
                     analyticsMeta = null;
+                    Log.d("Youboraaaaaa","isSourceEqual");
                 }
                 reloadSource();
             }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,6 +824,12 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
+        Log.d("Youboraaaaa: ","finishPlayerInitialization player: "+player);
+        Log.d("Youboraaaaa: ","finishPlayerInitialization youboraPlugin: "+youboraPlugin);
+        if (analyticsData != null) {
+            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+analyticsData.toString());
+            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+contentId);
+        }
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();
         }
@@ -2155,6 +2161,12 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
+        Log.d("Youboraaaaa: ","player: "+player);
+        Log.d("Youboraaaaa: ","youboraPlugin: "+youboraPlugin);
+        if (analyticsData != null) {
+            Log.d("Youboraaaaa: ","setAnalyticsMeta: "+analyticsData.toString());
+            Log.d("Youboraaaaa: ","setAnalyticsMeta: "+contentId);
+        }
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             initialiseYoubora();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -828,7 +828,7 @@ class ReactExoplayerView extends FrameLayout implements
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                this.youboraPlugin = null;
+                youboraPlugin = null;
             }
             
             if (youboraPlugin == null) {
@@ -1010,8 +1010,8 @@ class ReactExoplayerView extends FrameLayout implements
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                this.youboraPlugin = null;
-                this.contentId = null;
+                youboraPlugin = null;
+                contentId = null;
             }
         }
         if (adsLoader != null) {
@@ -1637,8 +1637,8 @@ class ReactExoplayerView extends FrameLayout implements
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
-                    this.youboraPlugin = null;
-                    this.contentId = null;
+                    youboraPlugin = null;
+                    contentId = null;
                 }
                 reloadSource();
             }
@@ -2166,7 +2166,7 @@ class ReactExoplayerView extends FrameLayout implements
             if (youboraPlugin != null) {
                 youboraPlugin.getAdapter().unregisterListeners();
                 youboraPlugin.getAdapter().fireStop();
-                this.youboraPlugin = null;
+                youboraPlugin = null;
             }
             if (youboraPlugin == null) {
                 initialiseYoubora();

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -624,9 +624,6 @@ class ReactExoplayerView extends FrameLayout implements
         if (activity == null) return;
 
         youboraPlugin.setActivity(activity);
-        Log.d("Youboraaaaaa","initialiseYoubora player: "+player);
-        Log.d("Youboraaaaaa","initialiseYoubora youboraPlugin: "+youboraPlugin);
-        Log.d("Youboraaaaaa","initialiseYoubora youboraPlugin.getAdapter(): "+youboraPlugin.getAdapter());
         if (player != null && youboraPlugin != null && youboraPlugin.getAdapter() == null) {
             Exoplayer2Adapter adapter = new Exoplayer2Adapter(player);
             youboraPlugin.setAdapter(adapter);
@@ -837,17 +834,8 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        // Log.d("Youboraaaaa","finishPlayerInitialization player: " + player);
-        // if (analyticsMeta != null){
-        //     Log.d("Youboraaaaa","finishPlayerInitialization analyticsMeta: " + analyticsMeta.toString());
-        //     Log.d("Youboraaaaa","finishPlayerInitialization check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
-        // }
-        // Log.d("Youboraaaaa","finishPlayerInitialization youboraPlugin: " + youboraPlugin);
-        // Log.d("Youboraaaaa","finishPlayerInitialization contentId: " + contentId);
-        // this.playerInitialised = true;
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
-            Log.d("Youboraaaaa","Initialised youbora inside finishPlayerInitialization");
             initialiseYoubora();
         }
     }
@@ -1646,7 +1634,6 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
-                Log.d("Youboraaaaaaa","isSourceEqual: "+isSourceEqual);
                 if (youboraPlugin != null) {
                     youboraPlugin.getAdapter().unregisterListeners();
                     youboraPlugin.getAdapter().fireStop();
@@ -2175,19 +2162,6 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
-        // if (analyticsData != null){
-        //     Log.d("Youboraaaaa","setAnalyticsMeta analyticsData: " + analyticsData.toString());
-        //     Log.d("Youboraaaaa","setAnalyticsMeta check for contentId different: " + contentId + analyticsMeta.getString("contentId"));
-        // }
-
-        // Log.d("Youboraaaaa","setAnalyticsMeta player: " + player);
-        // Log.d("Youboraaaaa","setAnalyticsMeta playerInitialised: " + playerInitialised);
-        // Log.d("Youboraaaaa","setAnalyticsMeta youboraPlugin: " + youboraPlugin);
-
-        // if (playerInitialised && player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-        //     Log.d("Youboraaaaa","Initialised youbora inside setAnalyticsMeta");
-        //     initialiseYoubora();
-        // }
     }
 
     public void setAssetId(String assetId) {

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -250,7 +250,6 @@ class ReactExoplayerView extends FrameLayout implements
     private long lastPos = -1;
     private long lastBufferDuration = -1;
     private long lastDuration = -1;
-    private boolean triedYouboraInit = false;
 
     private final Handler progressHandler = new Handler(Looper.getMainLooper()) {
         @Override
@@ -619,7 +618,6 @@ class ReactExoplayerView extends FrameLayout implements
             Exoplayer2Adapter adapter = new Exoplayer2Adapter(player);
             youboraPlugin.setAdapter(adapter);
             youboraPlugin.getAdapter().fireStart();
-            this.triedYouboraInit=false;
         }
     }
 
@@ -825,7 +823,6 @@ class ReactExoplayerView extends FrameLayout implements
         startBufferCheckTimer();
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-            this.triedYouboraInit=true;
             initialiseYoubora();
         }
     }
@@ -2158,7 +2155,6 @@ class ReactExoplayerView extends FrameLayout implements
         this.analyticsMeta = analyticsData;
 
         if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
-            // this.triedYouboraInit=true;
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -834,13 +834,13 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        Log.d("Youboraaaaa","finishPlayerInitialization: "+player);
-        Log.d("Youboraaaaa","finishPlayerInitialization"+this.analyticsMeta);
-        Log.d("Youboraaaaa","finishPlayerInitialization"+youboraPlugin);
-        Log.d("Youboraaaaa","finishPlayerInitialization"+contentId);
-        Log.d("Youboraaaaa","finishPlayerInitialization"+this.analyticsMeta.getString("contentId"));
+        Log.d("Youboraaaaa","finishPlayerInitialization1: " + player);
+        Log.d("Youboraaaaa","finishPlayerInitialization2: " + analyticsMeta);
+        Log.d("Youboraaaaa","finishPlayerInitialization3: " + youboraPlugin);
+        Log.d("Youboraaaaa","finishPlayerInitialization4: " + contentId);
+        Log.d("Youboraaaaa","finishPlayerInitialization5: " + analyticsMeta.getString("contentId"));
 
-        if (player != null && this.analyticsMeta != null && youboraPlugin == null && contentId != this.analyticsMeta.getString("contentId")) {
+        if (player != null && analyticsMeta != null && youboraPlugin == null && contentId != analyticsMeta.getString("contentId")) {
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -596,15 +596,6 @@ class ReactExoplayerView extends FrameLayout implements
         if (analyticsMeta.hasKey("appReleaseVersion")) {
             youboraOptions.setAppReleaseVersion(analyticsMeta.getString("appReleaseVersion"));
         }
-        if (analyticsMeta.hasKey("contentResource")) {
-            youboraOptions.setContentResource(analyticsMeta.getString("contentResource"));
-        }
-        if (analyticsMeta.hasKey("contentDuration")) {
-            youboraOptions.setContentDuration(analyticsMeta.getDouble("contentDuration"));
-        }
-        if (analyticsMeta.hasKey("contentResource")) {
-            youboraOptions.setContentResource(analyticsMeta.getString("contentResource"));
-        }
         if (analyticsMeta.hasKey("contentPlaybackType")) {
             youboraOptions.setContentPlaybackType(analyticsMeta.getString("contentPlaybackType"));
         }
@@ -629,8 +620,6 @@ class ReactExoplayerView extends FrameLayout implements
             youboraPlugin.setAdapter(adapter);
             youboraPlugin.getAdapter().fireStart();
             this.triedYouboraInit=false;
-            // Reset playerInitialised so that youbora detects it next time when we change channel
-            // this.playerInitialised = false;
         }
     }
 

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -824,7 +824,7 @@ class ReactExoplayerView extends FrameLayout implements
         applyModifiers();
         startBufferCheckTimer();
 
-        if (!triedYouboraInit && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
+        if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
             this.triedYouboraInit=true;
             initialiseYoubora();
         }
@@ -2153,8 +2153,8 @@ class ReactExoplayerView extends FrameLayout implements
     public void setAnalyticsMeta(ReadableMap analyticsData) {
         this.analyticsMeta = analyticsData;
 
-        if (!triedYouboraInit && player != null && youboraPlugin == null && (analyticsMeta != null && contentId != analyticsMeta.getString("contentId"))) {
-            this.triedYouboraInit=true;
+        if (player != null && youboraPlugin == null && (analyticsMeta != null && analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {
+            // this.triedYouboraInit=true;
             initialiseYoubora();
         }
     }

--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -826,8 +826,8 @@ class ReactExoplayerView extends FrameLayout implements
 
         Log.d("Youboraaaaa: ","finishPlayerInitialization player: "+player);
         Log.d("Youboraaaaa: ","finishPlayerInitialization youboraPlugin: "+youboraPlugin);
-        if (analyticsData != null) {
-            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+analyticsData.toString());
+        if (analyticsMeta != null) {
+            Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+analyticsMeta.toString());
             Log.d("Youboraaaaa: ","finishPlayerInitialization setAnalyticsMeta: "+contentId);
         }
         if (player != null && youboraPlugin == null && (analyticsMeta != null && !analyticsMeta.getBoolean("contentIsLive") && contentId != analyticsMeta.getString("contentId"))) {


### PR DESCRIPTION
There has been a change of how analytics meta gets initialised. It is little puzzling why order of execution between `setAnalyticsMeta` and `finishPlayerInitialization` is different between VOD and LIVE TV. We should not initialise youbora till the time player.prepare is called else youbora will not register it as a successful play.

PR focuses on ensuring that youbora initialises after player.prepare