### PR TITLE
fix:  player shows black screen on re-enter

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -202,7 +202,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc func applicationWillEnterForeground(notification:NSNotification!) {
         self.applyModifiers()
-        if _playInBackground {
+        if !_playInBackground {
             _playerLayer?.player = _player
             _playerViewController?.player = _player
         }


### PR DESCRIPTION
This is a known issue raised at: https://github.com/react-native-video/react-native-video/pull/3275
