### PR TITLE
fix(android): fix leak caused by removing lifecycle listener too early

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -386,6 +386,7 @@ class ReactExoplayerView extends FrameLayout implements
     public void onHostDestroy() {
         mainHandler.removeCallbacksAndMessages(null);
         stopPlayback();
+        themedReactContext.removeLifecycleEventListener(this);
     }
 
     public void cleanUpResources() {
@@ -1069,7 +1070,6 @@ class ReactExoplayerView extends FrameLayout implements
         }
         adsLoader = null;
         progressHandler.removeMessages(SHOW_PROGRESS);
-        themedReactContext.removeLifecycleEventListener(this);
         audioBecomingNoisyReceiver.removeListener();
         bandwidthMeter.removeEventListener(this);
     }


### PR DESCRIPTION
fix leak caused by removing lifecycle listener too early
* Fix lifecycle listener being removed too early
