### PR TITLE
fix:  SAAA-13282 -  Casting via Airplay is not working for iOS devices and user gets a Throbber with Black Screen

### DIFF
--- a/ios/Video/Features/RCTResourceLoaderDelegate.swift
+++ b/ios/Video/Features/RCTResourceLoaderDelegate.swift
@@ -113,7 +113,9 @@ class RCTResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSes
     }
 
     public func reset(){
-        //Airplay support changes
+         /**
+           * @TODO reset handler is added as a patch fix for handling airplay playback, Upgrading to v6.0.0 will fix this issue permantely and don't need the reset handler.
+         */
         _requestingCertificate = false;
     }
     

--- a/ios/Video/Features/RCTResourceLoaderDelegate.swift
+++ b/ios/Video/Features/RCTResourceLoaderDelegate.swift
@@ -111,6 +111,11 @@ class RCTResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSes
         
         return true
     }
+
+    public func reset(){
+        //Airplay support changes
+        _requestingCertificate = false;
+    }
     
     func handleDrm(_ loadingRequest:AVAssetResourceLoadingRequest!) -> Bool {
         if _requestingCertificate {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1206,7 +1206,9 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func handleExternalPlaybackActiveChange(player: AVPlayer, change: NSKeyValueObservedChange<Bool>) {
         guard let _player = _player else { return }
-        //Airplay support changes
+         /**
+           * @TODO reset handler is added as a patch fix for handling airplay playback, Upgrading to v6.0.0 will fix this issue permantely and don't need the reset handler.
+         */
         _resouceLoaderDelegate?.reset();
         onVideoExternalPlaybackChange?(["isExternalPlaybackActive": NSNumber(value: _player.isExternalPlaybackActive),
                                         "target": reactTag as Any])

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1206,6 +1206,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     func handleExternalPlaybackActiveChange(player: AVPlayer, change: NSKeyValueObservedChange<Bool>) {
         guard let _player = _player else { return }
+        //Airplay support changes
+        _resouceLoaderDelegate?.reset();
         onVideoExternalPlaybackChange?(["isExternalPlaybackActive": NSNumber(value: _player.isExternalPlaybackActive),
                                         "target": reactTag as Any])
     }


### PR DESCRIPTION
Fixes issue (https://github.com/TheWidlarzGroup/react-native-video/issues/3411) with play content on airplay which is having Fairplay DRM. It is a patch fix since we are using 6.0.0-aplha-7, The issue is permanently addressed in v6.0.0 
https://github.com/TheWidlarzGroup/react-native-video/pull/3578

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.

https://github.com/skytvnz/react-native-video/assets/131331213/83565a54-8040-486c-b397-bd24ea9b9876


