### PR TITLE
SAAA-13339 - User has to disconnect Airplay and connect again while changing VOD content within Browse button

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -301,7 +301,7 @@ export default class Video extends Component {
       this.setNativeProps({
         allowsExternalPlayback: false,
       });
-    } 
+    }
   }
   render() {
     const resizeMode = this.props.resizeMode;

--- a/Video.js
+++ b/Video.js
@@ -293,6 +293,17 @@ export default class Video extends Component {
     return UIManager.getViewManagerConfig(viewManagerName);
   };
 
+  componentWillUnmount() {
+      /**
+           * @TODO reset handler is added as a patch fix for handling airplay playback to release the stream , Upgrading to v6.0.0 will fix this issue permantely and don't need the reset handler.
+         */
+    if (Platform.OS === 'ios') {
+      this.setNativeProps({
+        allowsExternalPlayback: false
+      });
+    } 
+  }
+
   render() {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};

--- a/Video.js
+++ b/Video.js
@@ -299,11 +299,10 @@ export default class Video extends Component {
          */
     if (Platform.OS === 'ios') {
       this.setNativeProps({
-        allowsExternalPlayback: false
+        allowsExternalPlayback: false,
       });
     } 
   }
-
   render() {
     const resizeMode = this.props.resizeMode;
     const source = resolveAssetSource(this.props.source) || {};

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -474,6 +474,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     @objc
     func setAllowsExternalPlayback(_ allowsExternalPlayback:Bool) {
+          /**
+           * @TODO reset handler is added as a patch fix for handling airplay playback, Upgrading to v6.0.0 will fix this issue permantely and don't need the reset handler.
+         */
+        _resouceLoaderDelegate?.reset();
         _allowsExternalPlayback = allowsExternalPlayback
         _player?.allowsExternalPlayback = _allowsExternalPlayback
     }


### PR DESCRIPTION
https://skynz.atlassian.net/browse/SAAA-13339

We need to reset the drm details and license details while player mounts again in Watch TV or the VOD content and while unmounting we need to release the stream from airplay.

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.




https://github.com/skytvnz/react-native-video/assets/131331213/4d9a20b8-df57-4dd9-b165-2fab4417fea1


