### PR TITLE
feat: SAAA-13568 - Android - Align Subtitle position to bottom of the player in SkyGO

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -296,9 +296,10 @@ public final class ExoPlayerView extends FrameLayout implements AdViewProvider {
 
         @Override
         public void onCues(List<Cue> cues) {
+            final float LINE_POSITION = 0.8f;
             List<Cue> updatedCues = new ArrayList<>();
             for (Cue cue : cues) {
-                updatedCues.add(new Cue(cue.text, Layout.Alignment.ALIGN_CENTER, Cue.TYPE_UNSET, Cue.LINE_TYPE_FRACTION, Cue.TYPE_UNSET, Cue.DIMEN_UNSET, Cue.TYPE_UNSET, cue.size));
+                updatedCues.add(new Cue(cue.text, Layout.Alignment.ALIGN_CENTER, LINE_POSITION, Cue.LINE_TYPE_FRACTION, Cue.TYPE_UNSET, Cue.DIMEN_UNSET, Cue.TYPE_UNSET, cue.size));
             }
             subtitleLayout.setCues(updatedCues);
         }


### PR DESCRIPTION
https://skynz.atlassian.net/browse/SAAA-13568

Over-riding the default line position of the ExoPlayerView to show the subtitle to bottom of the player. 

![Screenshot_1722891900](https://github.com/user-attachments/assets/99f88d72-9f60-4be7-84b5-1e4e31209c1f)

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
